### PR TITLE
trial: add compatible zenoh version in `@version`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Zenohex.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.2.0+zenoh-0.10.1-rc"
   @source_url "https://github.com/b5g-ex/zenohex"
 
   def project do

--- a/native/zenohex_nif/Cargo.lock
+++ b/native/zenohex_nif/Cargo.lock
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "zenohex_nif"
-version = "0.2.0"
+version = "0.2.0+zenoh-0.10.1-rc"
 dependencies = [
  "flume",
  "futures",

--- a/native/zenohex_nif/Cargo.toml
+++ b/native/zenohex_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenohex_nif"
-version = "0.2.0"
+version = "0.2.0+zenoh-0.10.1-rc"
 authors = []
 edition = "2021"
 


### PR DESCRIPTION
This PR is a trial for #37 
The source code has not been changed at all from `0.2.0`, but the purpose of this PR is to check if there is any problem when we put the corresponding Zenoh version information after `+` in the version number. I will merge this and create tag/release for Hex to check that.