### PR TITLE
add permissions to write in nif_precomple

### DIFF
--- a/.github/workflows/nif_precompile.yml
+++ b/.github/workflows/nif_precompile.yml
@@ -9,6 +9,8 @@ jobs:
   build_release:
     name: NIF ${{ matrix.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Unfortunately, GitHub Actions to build precompiled NIFs when creating a new tag has failed,,,
https://github.com/biyooon-ex/zenohex/actions/runs/9661110070

According to the information on StackOverflow, we need to add permission to write content. I will try it. 
https://stackoverflow.com/questions/76362343/creating-a-release-using-github-action-fails-with-http-403