### PR TITLE
Add cargo of NIF module to dependabot target

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+  - package-ecosystem: "cargo"
+    directory: "/native/zenohex_nif"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This PR tries to enable dependabot automatic search of the update for cargo module used for Rustler NIF module.