### PR TITLE
Release v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can install this package into your project by adding `zenohex` to your list 
   defp deps do
     [
       ...
-      {:zenohex, "~> 0.3.0"},
+      {:zenohex, "~> 0.3.1"},
       ...
     ]
   end
@@ -122,7 +122,7 @@ When you want to build NIF module locally into your project, install Rustler by 
   defp deps do
     [
       ...
-      {:zenohex, "~> 0.2.0"},
+      {:zenohex, "~> 0.3.1"},
       {:rustler, ">= 0.0.0", optional: true},
       ...
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Zenohex.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.3.1"
   @source_url "https://github.com/biyooon-ex/zenohex"
 
   def project do

--- a/native/zenohex_nif/Cargo.lock
+++ b/native/zenohex_nif/Cargo.lock
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "zenohex_nif"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "flume",
  "futures",

--- a/native/zenohex_nif/Cargo.toml
+++ b/native/zenohex_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenohex_nif"
-version = "0.3.0"
+version = "0.3.1"
 authors = []
 edition = "2021"
 


### PR DESCRIPTION
This version is compatible with [Zenoh 0.11.0](https://github.com/eclipse-zenoh/zenoh/releases/tag/0.11.0)

* Add cargo of NIF module to dependabot target by @takasehideki in https://github.com/biyooon-ex/zenohex/pull/62
* Bump Rustler to 0.34.0 in Cargo.toml (not 0.35.0), IOW, downgrade in mix.exs by @takasehideki in https://github.com/biyooon-ex/zenohex/pull/69
* Bump by dependabot
  * Bump credo from 1.7.7 to 1.7.8 by @dependabot in https://github.com/biyooon-ex/zenohex/pull/63
  * Bump dialyxir from 1.4.3 to 1.4.4 by @dependabot in https://github.com/biyooon-ex/zenohex/pull/65
  * Bump futures from 0.3.30 to 0.3.31 in /native/zenohex_nif by @dependabot in https://github.com/biyooon-ex/zenohex/pull/64
  * Bump rustler_precompiled from 0.7.1 to 0.8.2 by @dependabot in https://github.com/biyooon-ex/zenohex/pull/60
  * Bump ex_doc from 0.34.1 to 0.34.2 by @dependabot in https://github.com/biyooon-ex/zenohex/pull/55
  * Bump flume from 0.11.0 to 0.11.1 in /native/zenohex_nif by @dependabot in https://github.com/biyooon-ex/zenohex/pull/66
  * Bump credo from 1.7.8 to 1.7.10 by @dependabot in https://github.com/biyooon-ex/zenohex/pull/72

**Full Changelog**: https://github.com/biyooon-ex/zenohex/compare/v0.3.0...v0.3.1