### PR TITLE
Bump Elixir and Erlang versions used for development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 env:
-  OTP_VERSION: 26.1.2
-  ELIXIR_VERSION: 1.15.7
+  OTP_VERSION: 27.1.2
+  ELIXIR_VERSION: 1.17.3
   MIX_ENV: test
 
 # based https://github.com/erlef/setup-beam

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.15.7-otp-26
-erlang 26.1.2
+elixir 1.17.3-otp-27
+erlang 27.1.2

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ This allows the creation and communication of a large number of fault-tolerant n
 We recommend you use the same version to communicate with other Zenoh clients or routers since version compatibility is somewhat important for Zenoh.
 Please also check the description on [Releases](https://github.com/biyooon-ex/zenohex/releases) about the corresponding Zenoh version.
 
+FYI, the development team currently uses the following versions.
+
+- Elixir 1.17.3-otp-27
+- Erlang/OTP 27.1.2
+- Rust 1.82.0
+
 ### Installation
 
 `zenohex` is [available in Hex](https://hex.pm/packages/zenohex).

--- a/mix.exs
+++ b/mix.exs
@@ -93,7 +93,9 @@ defmodule Zenohex.MixProject do
 
   defp test_coverage() do
     [
-      ignore_modules: [Zenohex.Nif]
+      ignore_modules: [Zenohex.Nif],
+      # WHY: see https://github.com/biyooon-ex/zenohex/issues/77
+      summary: [threshold: 80]
     ]
   end
 

--- a/test/zenohex/nif_test.exs
+++ b/test/zenohex/nif_test.exs
@@ -12,7 +12,7 @@ defmodule Zenohex.NifTest do
   describe "session" do
     for {type, value} <- [
           {"integer", 0},
-          {"float", 0.0},
+          {"float", +0.0},
           {"binary", :erlang.term_to_binary("binary")}
         ] do
       test "session_put_#{type}/2", %{session: session} do
@@ -63,7 +63,7 @@ defmodule Zenohex.NifTest do
 
     for {type, value} <- [
           {"integer", 0},
-          {"float", 0.0},
+          {"float", +0.0},
           {"binary", :erlang.term_to_binary("binary")}
         ] do
       test "publisher_put_#{type}/2", %{session: session} do
@@ -101,8 +101,8 @@ defmodule Zenohex.NifTest do
       Nif.publisher_put_integer(publisher, 0)
       assert {:ok, %Sample{value: 0}} = Nif.subscriber_recv_timeout(subscriber, 1000)
 
-      Nif.publisher_put_float(publisher, 0.0)
-      assert {:ok, %Sample{value: 0.0}} = Nif.subscriber_recv_timeout(subscriber, 1000)
+      Nif.publisher_put_float(publisher, +0.0)
+      assert {:ok, %Sample{value: +0.0}} = Nif.subscriber_recv_timeout(subscriber, 1000)
 
       Nif.publisher_put_binary(publisher, "binary")
       assert {:ok, %Sample{value: "binary"}} = Nif.subscriber_recv_timeout(subscriber, 1000)


### PR DESCRIPTION
In this PR, I'd like to suggest that Elixir and Erlang versions shall be bumped for development.
These are implicitly specified in `.tool-version`.
- Elixir: 1.15.7-otp-26 -> 1.17.3-otp-27
- Erlang/OTP: 26.1.2 -> 27.1.2

These are the latest versions that can be installed `asdf` at this time. Of course, keeping them fresh is preferable, but I think reviewing them at the proper timing is sufficient.

Also, I have added these version numbers (along with Rust) clearly in README.