### PR TITLE
Release v0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can install this package into your project by adding `zenohex` to your list 
   defp deps do
     [
       ...
-      {:zenohex, "~> 0.3.1"},
+      {:zenohex, "~> 0.3.2"},
       ...
     ]
   end
@@ -128,7 +128,7 @@ When you want to build NIF module locally into your project, install Rustler by 
   defp deps do
     [
       ...
-      {:zenohex, "~> 0.3.1"},
+      {:zenohex, "~> 0.3.2"},
       {:rustler, ">= 0.0.0", optional: true},
       ...
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Zenohex.MixProject do
   use Mix.Project
 
-  @version "0.3.1"
+  @version "0.3.2"
   @source_url "https://github.com/biyooon-ex/zenohex"
 
   def project do

--- a/native/zenohex_nif/Cargo.lock
+++ b/native/zenohex_nif/Cargo.lock
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "zenohex_nif"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "flume",
  "futures",

--- a/native/zenohex_nif/Cargo.toml
+++ b/native/zenohex_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenohex_nif"
-version = "0.3.1"
+version = "0.3.2"
 authors = []
 edition = "2021"
 


### PR DESCRIPTION
This version is compatible with [Zenoh 0.11.0](https://github.com/eclipse-zenoh/zenoh/releases/tag/0.11.0)

Although changes from v0.3.1 were only bumping to Elixir/Erlang versions for development and some minor fixes in test code, I decided to make a new release since the Zenoh v1.0 support we are working on next is expected to take some time.