### PR TITLE
Release v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can install this package into your project by adding `zenohex` to your list 
   defp deps do
     [
       ...
-      {:zenohex, "~> 0.3.2"},
+      {:zenohex, "~> 0.4.0"},
       ...
     ]
   end
@@ -129,7 +129,7 @@ When you want to build NIF module locally into your project, install Rustler by 
   defp deps do
     [
       ...
-      {:zenohex, "~> 0.3.2"},
+      {:zenohex, "~> 0.4.0"},
       {:rustler, ">= 0.0.0", optional: true},
       ...
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Zenohex.MixProject do
   use Mix.Project
 
-  @version "0.3.2"
+  @version "0.4.0"
   @source_url "https://github.com/biyooon-ex/zenohex"
 
   def project do

--- a/native/zenohex_nif/Cargo.lock
+++ b/native/zenohex_nif/Cargo.lock
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "zenohex_nif"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "log",
  "rustler",

--- a/native/zenohex_nif/Cargo.toml
+++ b/native/zenohex_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenohex_nif"
-version = "0.3.2"
+version = "0.4.0"
 authors = []
 edition = "2021"
 


### PR DESCRIPTION
This version is compatible with [Zenoh 1.4.0](https://github.com/eclipse-zenoh/zenoh/releases/tag/1.4.0)