### PR TITLE
Bump GHA upload-artifact to v4

### DIFF
--- a/.github/workflows/nif_precompile.yml
+++ b/.github/workflows/nif_precompile.yml
@@ -54,7 +54,7 @@ jobs:
         project-dir: "native/zenohex_nif"
 
     - name: Artifact upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.build-crate.outputs.file-name }}
         path: ${{ steps.build-crate.outputs.file-path }}


### PR DESCRIPTION
We observed "Build precompiled NIFs" by nif_precompile.yml has been failed due to the version of upload-artifact. So we bumped it. https://github.com/biyooon-ex/zenohex/actions/runs/16559378084/job/46826045547 https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/