### PR TITLE
Bump os in GHA jobs

### DIFF
--- a/.github/workflows/nif_precompile.yml
+++ b/.github/workflows/nif_precompile.yml
@@ -16,15 +16,15 @@ jobs:
       matrix:
         nif: ["2.15"]
         job:
-          - { target: aarch64-apple-darwin        , os: macos-12      }
-          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-22.04 , use-cross: true }
-          - { target: aarch64-unknown-linux-musl  , os: ubuntu-22.04 , use-cross: true }
-          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-22.04 , use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-12      }
+          - { target: aarch64-apple-darwin        , os: macos-14      }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-24.04 , use-cross: true }
+          - { target: aarch64-unknown-linux-musl  , os: ubuntu-24.04 , use-cross: true }
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-24.04 , use-cross: true }
+          - { target: x86_64-apple-darwin         , os: macos-14      }
           - { target: x86_64-pc-windows-gnu       , os: windows-2022  }
           - { target: x86_64-pc-windows-msvc      , os: windows-2022  }
-          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-22.04  }
-          - { target: x86_64-unknown-linux-musl   , os: ubuntu-22.04 , use-cross: true }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-24.04  }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-24.04 , use-cross: true }
 
     steps:
     - name: Checkout source code


### PR DESCRIPTION
This commit bumps OS image for GHA jobs.
`macos-12` we had been using seems to have been deprecated. So we decided to bump the other operating systems according to `-latest`. https://github.com/actions/runner-images?tab=readme-ov-file#available-images