### PR TITLE
Change os image to `latest` for precompiling NIF

### DIFF
--- a/.github/workflows/nif_precompile.yml
+++ b/.github/workflows/nif_precompile.yml
@@ -16,15 +16,15 @@ jobs:
       matrix:
         nif: ["2.15"]
         job:
-          - { target: aarch64-apple-darwin        , os: macos-14      }
-          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-24.04 , use-cross: true }
-          - { target: aarch64-unknown-linux-musl  , os: ubuntu-24.04 , use-cross: true }
-          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-24.04 , use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-14      }
-          - { target: x86_64-pc-windows-gnu       , os: windows-2022  }
-          - { target: x86_64-pc-windows-msvc      , os: windows-2022  }
-          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-24.04  }
-          - { target: x86_64-unknown-linux-musl   , os: ubuntu-24.04 , use-cross: true }
+          - { target: aarch64-apple-darwin        , os: macos-latest   }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-latest , use-cross: true }
+          - { target: aarch64-unknown-linux-musl  , os: ubuntu-latest , use-cross: true }
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-latest , use-cross: true }
+          - { target: x86_64-apple-darwin         , os: macos-latest   }
+          - { target: x86_64-pc-windows-gnu       , os: windows-latest }
+          - { target: x86_64-pc-windows-msvc      , os: windows-latest }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-latest  }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
 
     steps:
     - name: Checkout source code


### PR DESCRIPTION
This commit wants to change the OS image in nif_precompile on GitHub Actions. As we experienced in #104, a boring issue can arise when the version provided by GHA becomes deprecated. Since this repository is not so sensitive to OS versions for compiling NIFs, it is acceptable to fix it to `-latest`.