### PR TITLE
Restore goal for `mix test --cover` to default (90%)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -102,9 +102,7 @@ defmodule Zenohex.MixProject do
         Zenohex.Nif,
         ~r/Zenohex.Nif.Logger.*/,
         Zenohex.Examples.Plugins.StorageBackendFs
-      ],
-      # WHY: see https://github.com/biyooon-ex/zenohex/issues/77
-      summary: [threshold: 80]
+      ]
     ]
   end
 


### PR DESCRIPTION
Restore ec176d6 in #76
https://github.com/biyooon-ex/zenohex/pull/76#issuecomment-2458709372

Close https://github.com/biyooon-ex/zenohex/issues/77