### PR TITLE
release v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This allows the creation and communication of a large number of fault-tolerant n
 
 ## Usage
 
-**Currently, Zenohex uses version 1.5.0 of Zenoh.**
+**Currently, Zenohex uses version 1.5.1 of Zenoh.**
 
 We recommend you use the same version to communicate with other Zenoh clients or routers since version compatibility is somewhat important for Zenoh.
 Please also check the description on [Releases](https://github.com/biyooon-ex/zenohex/releases) about the corresponding Zenoh version.
@@ -49,7 +49,7 @@ You can install this package into your project by adding `zenohex` to your list 
   defp deps do
     [
       ...
-      {:zenohex, "~> 0.5.0"},
+      {:zenohex, "~> 0.5.1"},
       ...
     ]
   end
@@ -129,7 +129,7 @@ When you want to build NIF module locally into your project, install Rustler by 
   defp deps do
     [
       ...
-      {:zenohex, "~> 0.5.0"},
+      {:zenohex, "~> 0.5.1"},
       {:rustler, ">= 0.0.0", optional: true},
       ...
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Zenohex.MixProject do
   use Mix.Project
 
-  @version "0.5.0"
+  @version "0.5.1"
   @source_url "https://github.com/biyooon-ex/zenohex"
 
   def project do

--- a/native/zenohex_nif/Cargo.lock
+++ b/native/zenohex_nif/Cargo.lock
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "zenohex_nif"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "log",
  "rustler",

--- a/native/zenohex_nif/Cargo.toml
+++ b/native/zenohex_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenohex_nif"
-version = "0.5.0"
+version = "0.5.1"
 authors = []
 edition = "2021"
 


### PR DESCRIPTION
**Currently, Zenohex uses version 1.5.1 of Zenoh.**